### PR TITLE
Add StyledModal for general use

### DIFF
--- a/src/styled/StyledModal.js
+++ b/src/styled/StyledModal.js
@@ -1,0 +1,73 @@
+import { Modal } from 'antd';
+import styled from 'styled-components';
+
+const ModalStyled = styled(Modal)`
+  && {
+  }
+`;
+
+const { confirm, error, success, info } = ModalStyled;
+
+export const confirmModal = content => {
+  return () => {
+    return confirm({
+      ...content,
+      onOk() {
+        content.onOk || console.log('OK', content.title || '');
+      },
+      onCancel() {
+        content.onCancel || console.log('Cancel', content.title || '');
+      },
+    });
+  };
+};
+
+export const deleteModal = content => {
+  return () => {
+    return confirm({
+      ...content,
+      cancelText: content.cancelText || 'No',
+      okText: content.okText || 'Yes',
+      okType: content.okType || 'danger',
+      onOk() {
+        content.onOk || console.log('OK', content.title || '');
+      },
+      onCancel() {
+        content.onCancel || console.log('Cancel', content.title || '');
+      },
+    });
+  };
+};
+
+export const errorModal = content => {
+  return () => {
+    return error({
+      ...content,
+      onOk() {
+        content.onOk || console.log('OK', content.title || '');
+      },
+    });
+  };
+};
+
+export const successModal = content => {
+  return () => {
+    return success({
+      ...content,
+      onOk() {
+        content.onOk || console.log('OK', content.title || '');
+      },
+    });
+  };
+};
+
+export const infoModal = content => {
+  return () => {
+    return info({
+      ...content,
+      onOk() {
+        content.onOk || console.log('OK', content.title || '');
+      },
+    });
+  };
+};

--- a/src/styled/index.js
+++ b/src/styled/index.js
@@ -7,6 +7,7 @@ export * from './StyledLine';
 export * from './StyledSelect';
 export * from './StyledForm';
 export * from './StyledUploadImage';
+export * from './StyledModal';
 
 //Exports for form building
 export * from './Form Options/AntCheckbox';


### PR DESCRIPTION
# Description

Add confirmation modals for positive and destructive actions, as well as information modals for 
warning, error, and general info. 

Each modal returns a function that accepts a settings object. The spec for the setting object 
can be found on the [Ant Design spec](https://ant.design/components/modal/#Modal.method()), but the barebones basics is that you pass it a 
`title` and `content` string, as well as a function for `onOk` and `onCancel`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [✔️] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [✔️ ] This change requires a documentation update

## Change Status

- [✔️] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] My code follows the style guidelines of this project
- [✔️] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✔️] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [✔️] There are no merge conflicts
