### PR TITLE
Add confirmation modal to deleteOrg

### DIFF
--- a/src/styled/StyledModal.js
+++ b/src/styled/StyledModal.js
@@ -10,7 +10,7 @@ const { confirm, error, success, info } = ModalStyled;
 
 export const confirmModal = content => {
   return () => {
-    return confirm({
+    confirm({
       ...content,
       onOk() {
         content.onOk || console.log('OK', content.title || '');
@@ -24,24 +24,18 @@ export const confirmModal = content => {
 
 export const deleteModal = content => {
   return () => {
-    return confirm({
+    confirm({
       ...content,
       cancelText: content.cancelText || 'No',
       okText: content.okText || 'Yes',
       okType: content.okType || 'danger',
-      onOk() {
-        content.onOk || console.log('OK', content.title || '');
-      },
-      onCancel() {
-        content.onCancel || console.log('Cancel', content.title || '');
-      },
     });
   };
 };
 
 export const errorModal = content => {
   return () => {
-    return error({
+    error({
       ...content,
       onOk() {
         content.onOk || console.log('OK', content.title || '');
@@ -52,7 +46,7 @@ export const errorModal = content => {
 
 export const successModal = content => {
   return () => {
-    return success({
+    success({
       ...content,
       onOk() {
         content.onOk || console.log('OK', content.title || '');
@@ -63,7 +57,7 @@ export const successModal = content => {
 
 export const infoModal = content => {
   return () => {
-    return info({
+    info({
       ...content,
       onOk() {
         content.onOk || console.log('OK', content.title || '');

--- a/src/views/OrganizationDashboard.js
+++ b/src/views/OrganizationDashboard.js
@@ -12,7 +12,12 @@ import {
 import { useStateValue } from '../hooks/useStateValue';
 import EventList from '../components/EventList';
 import OrganizationInfo from '../components/OrganizationInfo';
-import { StyledButton, StyledAvatar, StyledUploadImage } from '../styled';
+import {
+  StyledButton,
+  StyledAvatar,
+  StyledUploadImage,
+  deleteModal,
+} from '../styled';
 
 export const OrganizationDashboard = () => {
   const [state, dispatch] = useStateValue();
@@ -54,8 +59,14 @@ export const OrganizationDashboard = () => {
   }, [displayOrg]);
 
   const deleteOrg = e => {
+    const deleteOrgModal = deleteModal({
+      title: 'Are you sure you want to delete this organization?',
+      content: 'This cannot be undone.',
+      onOk: () => deleteOrganization(displayOrg.orgId, dispatch),
+    });
+
     e.preventDefault();
-    deleteOrganization(displayOrg.orgId, dispatch);
+    deleteOrgModal();
   };
 
   const onFileUpload = path => {


### PR DESCRIPTION
# Description

Adds a confirmation modal when attempting to delete an organization.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [✔️] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [✔️] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist

- [✔️] I have performed a self-review of my own code
- [✔️] My changes generate no new warnings
