### PR TITLE
Switch checkable tags in browse to Select dropdown

### DIFF
--- a/src/components/MainDashboard/FilterTopbar.js
+++ b/src/components/MainDashboard/FilterTopbar.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useStateValue } from '../../hooks/useStateValue';
-import { Card, Form, Row, Input, Icon, Divider } from 'antd';
+import { Card, Form, Row, Col, Input, Icon, Divider, Select } from 'antd';
 import { StyledCheckableTag as CheckableTag } from '../../styled';
 
 const tabList = [
@@ -19,13 +19,19 @@ export const FilterTopbar = ({
   inputState,
   tagFilterState,
   tagExpandState,
+  selectedTags,
   toggleTagExpand,
   activeTab,
   setActiveTabKey,
 }) => {
   const [state, dispatch] = useStateValue();
   const [filterExpand, setFilterExpand] = useState(false);
-  const { onChange, onLocationChange, onTagsChange } = changeHandlers;
+  const {
+    onChange,
+    onLocationChange,
+    onTagsChange,
+    onSelectedChange,
+  } = changeHandlers;
 
   const toggleFilterExpand = () => {
     setFilterExpand(!filterExpand);
@@ -89,72 +95,104 @@ export const FilterTopbar = ({
     return <Row>{children}</Row>;
   };
 
+  const SelectableTags = ({ tags, onChange, collectionName, selectedTags }) => {
+    const { Option } = Select;
+    let children = [];
+
+    const changeHandler = selected => {
+      onChange(selected, collectionName);
+    };
+
+    for (let i = 0; i < tags.length; i++) {
+      children.push(<Option key={tags[i]}>{tags[i]}</Option>);
+    }
+
+    return (
+      <Select
+        name={collectionName}
+        onChange={changeHandler}
+        value={selectedTags[collectionName]}
+        showArrow
+        mode={'multiple'}
+        placeholder="Choose..."
+        style={{ width: 350 }}
+      >
+        {children}
+      </Select>
+    );
+  };
+
   const contentList = {
     Events: (
-      <Form layout="inline">
-        <CheckableTags
-          tags={state.tags.causeAreas}
-          onChange={onTagsChange}
-          collectionName="causeAreas"
-          tagFilterState={tagFilterState}
-          tagExpandState={tagExpandState}
-          toggleTagExpand={toggleTagExpand}
-        />
-        <Divider dashed style={{ marginTop: 16 }} />
-        <Row>
-          <Row style={{ fontSize: 18 }}>Location</Row>
-          <Form.Item label="City">
-            <Input
-              value={inputState.location.city}
-              name={'city'}
-              onChange={onLocationChange}
-              placeholder="City"
-            />
-          </Form.Item>
-          <Form.Item label="State">
-            <Input
-              value={inputState.location.state}
-              name={'state'}
-              onChange={onLocationChange}
-              placeholder="State Initials"
-            />
-          </Form.Item>
-        </Row>
-        <Divider dashed style={{ marginBottom: 8 }} />
-        <Row>
-          <a
-            style={{ marginLeft: 8, fontSize: 12 }}
-            onClick={toggleFilterExpand}
-          >
-            {filterExpand ? 'Hide Filters' : 'More Filters'}{' '}
-            <Icon type={filterExpand ? 'up' : 'down'} />
-          </a>
-        </Row>
-        <div style={{ display: filterExpand ? 'block' : 'none' }}>
-          <h5 style={{ fontFamily: 'Montserrat' }}>Interests</h5>
+      <div>
+        <Form layout="inline">
+          <CheckableTags
+            tags={state.tags.causeAreas}
+            onChange={onTagsChange}
+            collectionName="causeAreas"
+            tagFilterState={tagFilterState}
+            tagExpandState={tagExpandState}
+            toggleTagExpand={toggleTagExpand}
+          />
+          <Divider dashed style={{ marginTop: 16 }} />
           <Row>
-            <CheckableTags
-              tags={state.tags.interests}
-              onChange={onTagsChange}
-              collectionName="interests"
-              tagFilterState={tagFilterState}
-              tagExpandState={tagExpandState}
-              toggleTagExpand={toggleTagExpand}
-            />
+            <Row style={{ fontSize: 18 }}>Location</Row>
+            <Form.Item label="City">
+              <Input
+                value={inputState.location.city}
+                name={'city'}
+                onChange={onLocationChange}
+                placeholder="City"
+              />
+            </Form.Item>
+            <Form.Item label="State">
+              <Input
+                value={inputState.location.state}
+                name={'state'}
+                onChange={onLocationChange}
+                placeholder="State Initials"
+              />
+            </Form.Item>
           </Row>
-          <h5 style={{ fontFamily: 'Montserrat' }}>Volunteer Requirements</h5>
+          <Divider dashed style={{ marginBottom: 8 }} />
           <Row>
-            <CheckableTags
-              tags={state.tags.requirements}
-              onChange={onTagsChange}
-              collectionName="requirements"
-              tagFilterState={tagFilterState}
-              tagExpandState={tagExpandState}
-              toggleTagExpand={toggleTagExpand}
-            />
+            <a
+              style={{ marginLeft: 8, fontSize: 12 }}
+              onClick={toggleFilterExpand}
+            >
+              {filterExpand ? 'Hide Filters' : 'More Filters'}{' '}
+              <Icon type={filterExpand ? 'up' : 'down'} />
+            </a>
           </Row>
-        </div>
-      </Form>
+        </Form>
+        <Form
+          layout="inline"
+          style={{ display: filterExpand ? 'block' : 'none' }}
+        >
+          <Row>
+            <Col span={12}>
+              <Form.Item label="Interests">
+                <SelectableTags
+                  tags={state.tags.interests}
+                  onChange={onSelectedChange}
+                  collectionName="interests"
+                  selectedTags={selectedTags}
+                />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item label="Requirements">
+                <SelectableTags
+                  tags={state.tags.requirements}
+                  onChange={onSelectedChange}
+                  collectionName="requirements"
+                  selectedTags={selectedTags}
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+      </div>
     ),
     Organizations: (
       <Form layout="inline">

--- a/src/views/MainDashboard.js
+++ b/src/views/MainDashboard.js
@@ -25,6 +25,10 @@ export const MainDashboard = () => {
     requirements: {},
     causeAreas: {},
   });
+  const [selectedTags, setSelectedTags] = useState({
+    interests: [],
+    requirements: [],
+  });
   const [tagExpandState, setTagExpandState] = useState({
     interests: false,
     requirements: false,
@@ -48,6 +52,19 @@ export const MainDashboard = () => {
     });
     setTagFilterState(collectionMeta);
   }, []);
+
+  useEffect(() => {
+    let newTags = {};
+    Object.keys(selectedTags).forEach(collection => {
+      let newCollection = {};
+      Object.keys(tagFilterState[collection]).forEach(
+        tag => (newCollection[tag] = false)
+      );
+      selectedTags[collection].forEach(tag => (newCollection[tag] = true));
+      newTags[collection] = newCollection;
+    });
+    setTagFilterState({ ...tagFilterState, ...newTags });
+  }, [selectedTags]);
 
   //fetching user's location by IP
   useEffect(() => {
@@ -119,10 +136,28 @@ export const MainDashboard = () => {
 
   const onTagsChange = (e, name, collection) => {
     setFiltersTouched(true);
-    setTagFilterState({
-      ...tagFilterState,
-      [collection]: { ...tagFilterState[collection], [name]: e },
+    if (e === null)
+      setTagFilterState({
+        ...tagFilterState,
+        [collection]: {
+          ...tagFilterState[collection],
+          [name]: !tagFilterState[collection][name],
+        },
+      });
+    else
+      setTagFilterState({
+        ...tagFilterState,
+        [collection]: { ...tagFilterState[collection], [name]: e },
+      });
+  };
+
+  const onSelectedChange = (selected, collection) => {
+    setFiltersTouched(true);
+    selected.forEach(tag => {
+      console.log(tag);
+      onTagsChange(true, tag, collection);
     });
+    setSelectedTags({ ...selectedTags, [collection]: selected });
   };
 
   const toggleTagExpand = collectionName => {
@@ -138,9 +173,15 @@ export const MainDashboard = () => {
     <div className="main-content" style={{ maxWidth: 1020, margin: '0 auto' }}>
       <h2>Browse {activeTabKey}</h2>
       <FilterTopbar
-        changeHandlers={{ onChange, onLocationChange, onTagsChange }}
+        changeHandlers={{
+          onChange,
+          onLocationChange,
+          onTagsChange,
+          onSelectedChange,
+        }}
         inputState={inputState}
         tagFilterState={tagFilterState}
+        selectedTags={selectedTags}
         tagExpandState={tagExpandState}
         toggleTagExpand={toggleTagExpand}
         activeTab={activeTabKey}


### PR DESCRIPTION
Interests and Requirements tags are now searched using dropdown Select
object, instead of checkable tags. This necessitated the addition of the
selectedTags arrays in MainDashboard, along with a useEffect to manage
them.

We really need to get the state on that component under control.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback
