### PR TITLE
bug fix: events display on user profile and canceling recurring events

### DIFF
--- a/src/actions/events.js
+++ b/src/actions/events.js
@@ -636,7 +636,7 @@ export const cancelSignedUpRecurringEvent = (event, user, date, dispatch) => {
   let updatedUser = {
     ...user,
     registeredEvents: user.registeredEvents.filter(
-      item => item.eventId !== event.eventId,
+      item => !(item.eventId === event.eventId && item.date === targetDate)
     ),
   };
   

--- a/src/components/UserProfile/UserEvents.js
+++ b/src/components/UserProfile/UserEvents.js
@@ -55,7 +55,7 @@ export const UserEvents = ({ events, changePanel, calendarValue, selectDate, sel
             return (
               <StyledPanel
                 header={event.nameOfEvent}
-                key={event.eventId}
+                key={event.eventId + '-' + event.date}
               >
                 <h5>Date: {moment.unix(event.date).format('LL')}</h5>
                 <h5>Time: {`${event.startTime}~${event.endTime}`}</h5>


### PR DESCRIPTION
# Description
- bug fix: if user signed up for multiple days of the recurring events, open one on the event panel on user profile will open the rest. fixed by setting the key to event id plus date to ensure that it will be unique
- bug fix: if user signed up for multiple days of the recurring events, canceling one will cancel all. fixed by making the canceling recurrent events action more stringent to remove item that matches both the event id and the date 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
